### PR TITLE
[MerkleTreeApi] Add Framework and Create Endpoint

### DIFF
--- a/MerkleTreeApi/Controllers/UserBalanceController.cs
+++ b/MerkleTreeApi/Controllers/UserBalanceController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace MerkleTreeApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UserBalanceController : ControllerBase
+{
+    private readonly ILogger<UserBalanceController> _logger;
+
+    public UserBalanceController(ILogger<UserBalanceController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet("create")]
+    public ActionResult<string> Create() {
+        return "Hello from Controller!";
+    }
+}

--- a/MerkleTreeApi/Controllers/UserBalanceController.cs
+++ b/MerkleTreeApi/Controllers/UserBalanceController.cs
@@ -2,19 +2,40 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace MerkleTreeApi.Controllers;
 
+public class CreateRequest {
+    public List<User> user_data { get; set; } = new();
+    public string? leaf_tag { get; set; }
+    public string? branch_tag { get; set; }
+}
+
+public class User {
+    public int id { get; set;}
+    public int balance { get; set; }
+
+    public string Serialization() {
+        return string.Format("({0},{1})", this.id, this.balance);
+    }
+}
+
 [ApiController]
 [Route("api/[controller]")]
 public class UserBalanceController : ControllerBase
 {
     private readonly ILogger<UserBalanceController> _logger;
 
+    private  MerkleTree.MerkleTree _merkle_tree;
+
     public UserBalanceController(ILogger<UserBalanceController> logger)
     {
         _logger = logger;
+        _merkle_tree = new MerkleTree.MerkleTree();
     }
 
-    [HttpGet("create")]
-    public ActionResult<string> Create() {
-        return "Hello from Controller!";
+    [HttpPost("create")]
+    // public ActionResult<string> Create() {
+    public IActionResult Create([FromBody] CreateRequest request) {
+        string[] payloads = request.user_data.ConvertAll(e => e.Serialization()).ToArray(); 
+        string result = _merkle_tree.Build(payloads, request.leaf_tag!, request.branch_tag!);
+        return Ok(new { Status = "Ok", Details = result });;
     }
 }

--- a/MerkleTreeApi/MerkleTreeApi.csproj
+++ b/MerkleTreeApi/MerkleTreeApi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.12" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/MerkleTreeApi/MerkleTreeApi.csproj
+++ b/MerkleTreeApi/MerkleTreeApi.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\MerkleTree\MerkleTree.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/MerkleTreeApi/MerkleTreeApi.http
+++ b/MerkleTreeApi/MerkleTreeApi.http
@@ -1,6 +1,6 @@
 @MerkleTreeApi_HostAddress = http://localhost:5296
 
-GET {{MerkleTreeApi_HostAddress}}/api/userbalance/create
+POST {{MerkleTreeApi_HostAddress}}/api/userbalance/create
 Accept: application/json
 
 ###

--- a/MerkleTreeApi/MerkleTreeApi.http
+++ b/MerkleTreeApi/MerkleTreeApi.http
@@ -1,0 +1,6 @@
+@MerkleTreeApi_HostAddress = http://localhost:5296
+
+GET {{MerkleTreeApi_HostAddress}}/api/userbalance/create
+Accept: application/json
+
+###

--- a/MerkleTreeApi/Program.cs
+++ b/MerkleTreeApi/Program.cs
@@ -1,0 +1,25 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/MerkleTreeApi/Properties/launchSettings.json
+++ b/MerkleTreeApi/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:54284",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5296",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7014;http://localhost:5296",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/MerkleTreeApi/appsettings.Development.json
+++ b/MerkleTreeApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/MerkleTreeApi/appsettings.json
+++ b/MerkleTreeApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/MerkleTreeApp.sln
+++ b/MerkleTreeApp.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MerkleTreeTest", "MerkleTre
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MerkleTreeMain", "MerkleTreeMain\MerkleTreeMain.csproj", "{BAE817C9-18C4-40DB-98AE-262A0BBF86A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MerkleTreeApi", "MerkleTreeApi\MerkleTreeApi.csproj", "{D3235225-2258-444E-9078-4429535E361A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{BAE817C9-18C4-40DB-98AE-262A0BBF86A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BAE817C9-18C4-40DB-98AE-262A0BBF86A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BAE817C9-18C4-40DB-98AE-262A0BBF86A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3235225-2258-444E-9078-4429535E361A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3235225-2258-444E-9078-4429535E361A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3235225-2258-444E-9078-4429535E361A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3235225-2258-444E-9078-4429535E361A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Added webapi C# framework as a web server
- Add endpoint api/userbalance/create accept a post json request containing
  a list of user balances, build merkle tree and return its root hash in
hex format. Each request body contains:
  - user_data: A list of User object which contains an int id field and
    int balance field
  - leaf_tag: A string used for leaf node hashing tag
  - branch_tag: A string used for branch node hashing tag